### PR TITLE
Fix code scanning alert no. 8: Database query built from user-controlled sources

### DIFF
--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -78,7 +78,7 @@ router.post('/reset-password', validate('reset-password'), async (req, res) => {
 
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
-    const user = await User.findOne({ email });
+    const user = await User.findOne({ email: { $eq: email } });
 
     if (!user || decoded.userId !== user._id.toString()) {
       return res.status(401).json({ message: 'Token inválido ou usuário não encontrado' });


### PR DESCRIPTION
Fixes [https://github.com/Jonhvmp/ClientHub/security/code-scanning/8](https://github.com/Jonhvmp/ClientHub/security/code-scanning/8)

To fix the problem, we need to ensure that the `email` value is treated as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. This approach ensures that the user input is interpreted as a literal value, mitigating the risk of NoSQL injection.

- Modify the query on line 81 to use the `$eq` operator.
- No additional imports or dependencies are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
