### PR TITLE
Fix code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -21,7 +21,8 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.6.3",
     "morgan": "^1.10.0",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^1.4.5-lts.1",
+    "express-rate-limit": "^7.4.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.7"

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -6,6 +6,14 @@ const jwt = require('jsonwebtoken');
 const router = express.Router();
 const { registerUser, loginUser } = require('../controllers/authController');
 const { protect } = require('../middleware/authMiddleware');
+const rateLimit = require('express-rate-limit');
+
+// Rate limiter for forgot-password route
+const forgotPasswordLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 5, // limit each IP to 5 requests per windowMs
+  message: 'Too many requests, please try again later.'
+});
 
 // Função para validar entradas com base na rota
 const validate = (method) => {
@@ -50,7 +58,7 @@ router.get('/', protect, (req, res) => {
 });
 
 // Esqueceu a senha
-router.post('/forgot-password', validate('forgot-password'), async (req, res) => {
+router.post('/forgot-password', forgotPasswordLimiter, validate('forgot-password'), async (req, res) => {
   const { email } = req.body;
 
   try {


### PR DESCRIPTION
Fixes [https://github.com/Jonhvmp/ClientHub/security/code-scanning/5](https://github.com/Jonhvmp/ClientHub/security/code-scanning/5)

To fix the problem, we will introduce a rate-limiting middleware using the `express-rate-limit` package. This middleware will limit the number of requests a client can make to the `/forgot-password` endpoint within a specified time window. We will configure the rate limiter to allow a maximum of 5 requests per minute for this endpoint.

1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the `backend/routes/authRoutes.js` file.
3. Configure the rate limiter with appropriate settings.
4. Apply the rate limiter to the `/forgot-password` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
